### PR TITLE
remove ability to specify output directory

### DIFF
--- a/CIAOLoop
+++ b/CIAOLoop
@@ -604,21 +604,6 @@ sub readParameterFile {
 	  undef $value;
       }
 
-      # get output directory
-      elsif ($line =~ /^outputDir(\z|[\s\=])/i) {
-	  my (undef,$value) = split /=/, $line, 2;
-	  (undef,$value) = split " ", $line, 2 unless (defined($value));
-	  $value =~ s/^\s+//;
-	  die "No output directory given on line $lineNumber of $parameterFile.\n"
-	      unless ($value);
-	  $value =~ s/\s/\_/g;
-	  ($outputDir) = glob($value);
-	  undef $value;
-
-	  mkdir $outputDir, 0755 or die "Couldn't create directory: $outputDir.\n" unless (-d $outputDir);
-	  $outputDir .= "/" unless ($outputDir =~ /\/$/);
-      }
-
       # get cloudy run mode
       elsif ($line =~ /^cloudyRunMode(\z|[\s\=])/) {
 	  my (undef,$value) = split /=/, $line, 2;


### PR DESCRIPTION
This ignores the outputDir parameter from the input .par file, and instead just sets the output directory to the current working directory (by setting outputDir = "").

This is required to use the current (July 2022) development version of Cloudy (available from https://gitlab.nublado.org/cloudy/cloudy/-/tree/master), which does not support writing output files anywhere except the current working directory.

Fixes https://github.com/brittonsmith/cloudy_cooling_tools/issues/3